### PR TITLE
ANTLR + ASTBuilder - Team 2

### DIFF
--- a/src/main/java/com/auberer/compilerdesignlectureproject/antlr/ASTBuilder.java
+++ b/src/main/java/com/auberer/compilerdesignlectureproject/antlr/ASTBuilder.java
@@ -3,6 +3,7 @@ package com.auberer.compilerdesignlectureproject.antlr;
 import com.auberer.compilerdesignlectureproject.antlr.gen.TInfBaseVisitor;
 import com.auberer.compilerdesignlectureproject.antlr.gen.TInfParser;
 import com.auberer.compilerdesignlectureproject.ast.*;
+import com.auberer.compilerdesignlectureproject.lexer.TokenType;
 import com.auberer.compilerdesignlectureproject.reader.CodeLoc;
 import org.antlr.v4.runtime.ParserRuleContext;
 
@@ -81,6 +82,14 @@ public class ASTBuilder extends TInfBaseVisitor<ASTNode> {
   // Team 1
 
   // Team 2
+  @Override
+  public ASTNode visitWhileLoop(TInfParser.WhileLoopContext ctx) {
+    ASTWhileLoopStmtNode node = new ASTWhileLoopStmtNode();
+    enterNode(node, ctx);
+    visitChildren(ctx);
+    exitNode(node);
+    return node;
+  }
 
   // Team 3
 


### PR DESCRIPTION

### AST handling for whileLoop:
Added the `visitWhileLoop` method to process `while` loop constructs, creating an `ASTWhileLoopStmtNode` and managing its lifecycle within the AST.
