### PR TITLE
TypeChecker - Team 2

### DIFF
--- a/src/main/java/com/auberer/compilerdesignlectureproject/ast/ASTWhileLoopNode.java
+++ b/src/main/java/com/auberer/compilerdesignlectureproject/ast/ASTWhileLoopNode.java
@@ -1,11 +1,14 @@
 package com.auberer.compilerdesignlectureproject.ast;
 
 import com.auberer.compilerdesignlectureproject.lexer.TokenType;
+import com.auberer.compilerdesignlectureproject.sema.Scope;
 
 import java.util.HashSet;
 import java.util.Set;
 
 public class ASTWhileLoopNode extends ASTNode {
+
+  private Scope scope;
 
   @Override
   public <T> T accept(ASTVisitor<T> visitor) {
@@ -26,4 +29,10 @@ public class ASTWhileLoopNode extends ASTNode {
     return getChild(ASTTernaryExprNode.class, 0);
   }
 
+    public Scope getScope() {
+        return scope;
+    }
+    public void setScope(Scope scope) {
+        this.scope = scope;
+    }
 }

--- a/src/main/java/com/auberer/compilerdesignlectureproject/sema/SymbolTableBuilder.java
+++ b/src/main/java/com/auberer/compilerdesignlectureproject/sema/SymbolTableBuilder.java
@@ -74,6 +74,7 @@ public class SymbolTableBuilder extends ASTSemaVisitor<Void> {
   public Void visitWhileLoopStmt(ASTWhileLoopNode node) {
 
     Scope whileScope = currentScope.peek().createChildScope();
+    node.setScope(whileScope);
     currentScope.push(whileScope);
 
     visitChildren(node);

--- a/src/main/java/com/auberer/compilerdesignlectureproject/sema/TypeChecker.java
+++ b/src/main/java/com/auberer/compilerdesignlectureproject/sema/TypeChecker.java
@@ -295,6 +295,28 @@ public class TypeChecker extends ASTSemaVisitor<ExprResult> {
   }
 
   @Override
+  public ExprResult visitWhileLoopStmt(ASTWhileLoopNode node) {
+    Scope whileLoopScope = node.getScope();
+    currentScope.push(whileLoopScope);
+
+    ASTTernaryExprNode conditionNode = node.getCondition();
+    ExprResult exprResult = visit(conditionNode);
+    if (!exprResult.getType().is(SuperType.TYPE_BOOL)) {
+      throw new SemaError(node, "Wrong type: " + exprResult.getType().toString() + ". Type must be bool");
+    }
+
+    ASTStmtLstNode bodyNode = node.getBody();
+    visit(bodyNode);
+
+    assert currentScope.peek() == whileLoopScope;
+    currentScope.pop();
+
+    Type resultType = new Type(SuperType.TYPE_INVALID);
+    return new ExprResult(node.setEvaluatedSymbolType(resultType));
+  }
+
+
+  @Override
   public ExprResult visitAnonymousBlockStmt(ASTAnonymousBlockStmtNode node) {
     Scope scope = node.getScope();
     currentScope.push(scope);
@@ -445,5 +467,8 @@ public class TypeChecker extends ASTSemaVisitor<ExprResult> {
     }
     return null;
   }
+
+
+
 
 }

--- a/src/test-e2e/while-loop-type-checker/args.txt
+++ b/src/test-e2e/while-loop-type-checker/args.txt
@@ -1,0 +1,1 @@
+-symtab ./src/test-e2e/while-loop-type-checker/source.tinf

--- a/src/test-e2e/while-loop-type-checker/out.txt
+++ b/src/test-e2e/while-loop-type-checker/out.txt
@@ -1,0 +1,56 @@
+Compiling with own parser...
+Dumping scopes with symbol tables ...
+{
+  "level": 0,
+  "children": [
+    {
+      "level": 1,
+      "children": [
+        {
+          "level": 2,
+          "children": [ ],
+          "symbolTable": {
+            "symbols": {
+              "a": {
+                "name": "a",
+                "isUsed": false,
+                "isParam": false,
+                "type": {
+                  "superType": "TYPE_INVALID",
+                  "subType": null
+                }
+              }
+            }
+          }
+        }
+      ],
+      "symbolTable": {
+        "symbols": {
+          "i": {
+            "name": "i",
+            "isUsed": true,
+            "isParam": false,
+            "type": {
+              "superType": "TYPE_INVALID",
+              "subType": null
+            }
+          }
+        }
+      }
+    }
+  ],
+  "symbolTable": {
+    "symbols": {
+      "main": {
+        "name": "main",
+        "isUsed": false,
+        "isParam": false,
+        "type": {
+          "superType": "TYPE_INVALID",
+          "subType": null
+        }
+      }
+    }
+  }
+}
+Compilation successful!

--- a/src/test-e2e/while-loop-type-checker/source.tinf
+++ b/src/test-e2e/while-loop-type-checker/source.tinf
@@ -1,0 +1,9 @@
+int main := () {
+  int i = 3;
+  while (i != 24) {
+    i = i * 2;
+    int a = i + 1;
+  }
+
+  ret i;
+}


### PR DESCRIPTION
* **AST Updates**:
  - Added a `Scope` field to the `ASTWhileLoopNode` class, along with getter and setter methods

* **Symbol Table Integration**:
  - Updated the `SymbolTableBuilder` to create and assign a child scope for `while` loop nodes during semantic analysis.

* **Type Checking**:
  - Implemented a new `visitWhileLoopStmt` method in the `TypeChecker`
